### PR TITLE
Add an option `--use-rmdir` to use `rmdir` instead of `rm -R`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,7 @@ intended you have no right to complain ;-).
    remote system over SSH)."
    "``-n``, ``--dry-run``","Don't make any changes, just print what would be done. This makes it easy
    to evaluate the impact of a rotation scheme without losing any backups."
+   "``-D``, ``--use-rmdir``","Use ""rmdir"" to remove the backups (useful with CephFS snapshots for example)."
    "``-v``, ``--verbose``",Increase logging verbosity (can be repeated).
    "``-q``, ``--quiet``",Decrease logging verbosity (can be repeated).
    "``-h``, ``--help``",Show this message and exit.
@@ -359,8 +360,8 @@ Supported configuration options
   - If an include or exclude list is defined in the configuration file it
     overrides the include or exclude list given on the command line.
 
-- The ``prefer-recent``, ``strict`` and ``use-sudo`` options expect a boolean
-  value (``yes``, ``no``, ``true``, ``false``, ``1`` or ``0``).
+- The ``prefer-recent``, ``strict``, ``rmdir`` and ``use-sudo`` options expect a
+  boolean value (``yes``, ``no``, ``true``, ``false``, ``1`` or ``0``).
 
 - The ``ionice`` option expects one of the I/O scheduling class names ``idle``,
   ``best-effort`` or ``realtime``.

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -154,6 +154,12 @@ Supported options:
     Don't make any changes, just print what would be done. This makes it easy
     to evaluate the impact of a rotation scheme without losing any backups.
 
+  -D, --use-rmdir
+
+    Remove backups by calling `rmdir' to directly remove the whole directory
+    instead of deleting each of the files in it. This works only with special
+    directories such as CephFS snapshot.
+
   -v, --verbose
 
     Increase logging verbosity (can be repeated).
@@ -202,10 +208,10 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:unvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uDnvqh', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
-            'ionice=', 'config=', 'use-sudo', 'dry-run', 'verbose', 'quiet',
+            'ionice=', 'config=', 'use-sudo', 'dry-run', 'use-rmdir', 'verbose', 'quiet',
             'help',
         ])
         for option, value in options:
@@ -241,6 +247,8 @@ def main():
             elif option in ('-n', '--dry-run'):
                 logger.info("Performing a dry run (because of %s option) ..", option)
                 kw['dry_run'] = True
+            elif option in ('-D', '--use-rmdir'):
+                kw['rmdir'] = True
             elif option in ('-v', '--verbose'):
                 coloredlogs.increase_verbosity()
             elif option in ('-q', '--quiet'):


### PR DESCRIPTION
This is useful when the backups are CephFS snapshots.
Those are usually located in a special hidden directory (normally `.snap`) and cannot be removed by rm -R
(because they're read-only) but they can be removed by calling rmdir directly on the non-empty directory.
For example a simple backup procedure could be :
* mount cephfs to /backup
* backup the system to /backup
* make a snapshot with `mkdir /backup/.snap/<date>`
* rotate snapshots with `rotate-backups --use-rmdir /backup/.snap/`