### PR TITLE
test: add a test for allowing numbers in ionice class

### DIFF
--- a/rotate_backups/tests.py
+++ b/rotate_backups/tests.py
@@ -118,6 +118,9 @@ class RotateBackupsTestCase(TestCase):
         # Test that an invalid ionice scheduling class causes an error to be reported.
         returncode, output = run_cli(main, '--ionice=unsupported-class')
         assert returncode != 0
+        # Test that a numbered ionice scheduling class does not causes an error.
+        returncode, output = run_cli(main, '--ionice=3')
+        assert returncode == 0
         # Test that an invalid rotation scheme causes an error to be reported.
         returncode, output = run_cli(main, '--hourly=not-a-number')
         assert returncode != 0


### PR DESCRIPTION
Currently not possible to user numbers for ionice, which it should be when running busybox implementation of ionice.

Look at pull request xolox/python-executor/pull/16 for more information :)

EDIT: Keep in mind, this will fail until the dependency from python-executor gets updated.