### PR TITLE
Add UNIX timestamp extraction

### DIFF
--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -165,6 +165,10 @@ Supported options:
     single 'rmdir' command (even though according to POSIX semantics this
     command should refuse to remove nonempty directories, but I digress).
 
+  -t, --timestamp
+
+    Expect UNIX timestamps instead of dates.
+
   -v, --verbose
 
     Increase logging verbosity (can be repeated).
@@ -214,11 +218,11 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uC:nvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uC:ntvqh', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
             'ionice=', 'config=', 'use-sudo', 'dry-run', 'removal-command=',
-            'verbose', 'quiet', 'help',
+            'timestamp', 'verbose', 'quiet', 'help',
         ])
         for option, value in options:
             if option in ('-M', '--minutely'):
@@ -257,6 +261,8 @@ def main():
                 removal_command = shlex.split(value)
                 logger.info("Using custom removal command: %s", removal_command)
                 kw['removal_command'] = removal_command
+            elif option in ('-t', '--timestamp'):
+                kw['timestamp'] = True
             elif option in ('-v', '--verbose'):
                 coloredlogs.increase_verbosity()
             elif option in ('-q', '--quiet'):

--- a/rotate_backups/tests.py
+++ b/rotate_backups/tests.py
@@ -140,6 +140,19 @@ class RotateBackupsTestCase(TestCase):
             returncode, output = run_cli(main, '-n', '/root')
             assert returncode != 0
 
+    def test_unix_timestamp_dates(self):
+        """Make sure unix timestamps get extracted."""
+        with TemporaryDirectory(prefix='rotate-backups-', suffix='-test-suite') as root:
+            file_with_milliseconds = os.path.join(root, 'snapshot-1548460800311.bak.tar.gz')
+            file_with_seconds = os.path.join(root, 'snapshot-1548380800.bak.tar.gz')
+            for filename in file_with_milliseconds, file_with_seconds:
+                touch(filename)
+            program = RotateBackups(rotation_scheme=dict(monthly='always'), timestamp=True)
+            backups = program.collect_backups(root)
+            assert len(backups) == 2
+            assert backups[0].pathname == file_with_seconds
+            assert backups[1].pathname == file_with_milliseconds
+
     def test_invalid_dates(self):
         """Make sure filenames with invalid dates don't cause an exception."""
         with TemporaryDirectory(prefix='rotate-backups-', suffix='-test-suite') as root:


### PR DESCRIPTION
Some backup solutions prefer using UNIX timestamps for tagging backup
files or directories. In order to enable the rotation of such
files/directories an extra switch is added to enable scanning for UNIX
timestamps in file- or directory-names.

If a number is found and a ValueError is raised, the extractor tries if
it is a valid milliseconds-timestamp.