### PR TITLE
add option patronizemenot aka do_prerun_fs_checks=false

### DIFF
--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -276,6 +276,13 @@ class RotateBackups(PropertyManager):
         """
         return False
 
+    @mutable_property
+    def do_prerun_fs_checks(self):
+        """
+        :data:`False` to skip pre-run checks
+        """
+        return True
+
     @cached_property(writable=True)
     def exclude_list(self):
         """
@@ -469,7 +476,7 @@ class RotateBackups(PropertyManager):
             logger.info("No backups found in %s.", location)
             return
         # Make sure the directory is writable.
-        if not self.dry_run:
+        if not self.dry_run and self.do_prerun_fs_checks:
             location.ensure_writable()
         most_recent_backup = sorted_backups[-1]
         # Group the backups by the rotation frequencies.
@@ -556,7 +563,8 @@ class RotateBackups(PropertyManager):
         backups = []
         location = coerce_location(location)
         logger.info("Scanning %s for backups ..", location)
-        location.ensure_readable()
+        if  self.do_prerun_fs_checks:
+            location.ensure_readable()
         for entry in natsort(location.context.list_entries(location.directory)):
             match = TIMESTAMP_PATTERN.search(entry)
             if match:

--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -280,6 +280,10 @@ class RotateBackups(PropertyManager):
     def do_prerun_fs_checks(self):
         """
         :data:`False` to skip pre-run checks
+
+        When :data:`True`, as is the default, the script will check if directories are writeable and readable
+        before continuing to execute. This might have side-effects on some systems and produce wrong
+        error messages, in which case you should disable the option.
         """
         return True
 
@@ -563,7 +567,7 @@ class RotateBackups(PropertyManager):
         backups = []
         location = coerce_location(location)
         logger.info("Scanning %s for backups ..", location)
-        if  self.do_prerun_fs_checks:
+        if self.do_prerun_fs_checks:
             location.ensure_readable()
         for entry in natsort(location.context.list_entries(location.directory)):
             match = TIMESTAMP_PATTERN.search(entry)

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -165,6 +165,12 @@ Supported options:
     single 'rmdir' command (even though according to POSIX semantics this
     command should refuse to remove nonempty directories, but I digress).
 
+  -z, --patronizemenot
+
+    Skip all checks of existance or writeablitiy of directory or files.
+    Commands will just fail. Enables rotate-backups to work in more
+    secure setups and with e.g. apparmor, firejail or sudo restrictions
+
   -v, --verbose
 
     Increase logging verbosity (can be repeated).
@@ -214,11 +220,11 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uC:nvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uC:nvqhz', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
             'ionice=', 'config=', 'use-sudo', 'dry-run', 'removal-command=',
-            'verbose', 'quiet', 'help',
+            'verbose', 'quiet', 'help', 'patronizemenot'
         ])
         for option, value in options:
             if option in ('-M', '--minutely'):
@@ -243,6 +249,8 @@ def main():
                 kw['prefer_recent'] = True
             elif option in ('-r', '--relaxed'):
                 kw['strict'] = False
+            elif option in ('-z', '--patronizemenot'):
+                kw['do_prerun_fs_checks'] = False
             elif option in ('-i', '--ionice'):
                 value = validate_ionice_class(value.lower().strip())
                 kw['io_scheduling_class'] = value

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -224,7 +224,7 @@ def main():
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
             'ionice=', 'config=', 'use-sudo', 'dry-run', 'removal-command=',
-            'verbose', 'quiet', 'help', 'patronizemenot'
+            'verbose', 'quiet', 'help', 'patronizemenot',
         ])
         for option, value in options:
             if option in ('-M', '--minutely'):


### PR DESCRIPTION
This is a workaround for issue #18 and allows the script to be used in a setup where the script does not have write permissions on a directory but the remove-command does. It also allows using the script with zfs snapshots, which are stored in a hidden .zfs/snapshot directory for which the existence check fails.