### PR TITLE
New timestamp pattern option

### DIFF
--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -572,8 +572,6 @@ class RotateBackups(PropertyManager):
                     logger.verbose("Excluded %s (it didn't match the include list).", entry)
                 else:
                     try:
-#                        for group in match.groups('0'):
-#                            print group
                         backups.append(Backup(
                             pathname=os.path.join(location.directory, entry),
                             timestamp=datetime.datetime(*(int(group, 10) for group in match.groups('0'))),

--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -564,7 +564,6 @@ class RotateBackups(PropertyManager):
         location.ensure_readable()
         pattern=re.compile(self.timestamp, re.VERBOSE)
         for entry in natsort(location.context.list_entries(location.directory)):
-#            match = TIMESTAMP_PATTERN.search(entry)
             match = pattern.search( entry)
             if match:
                 if self.exclude_list and any(fnmatch.fnmatch(entry, p) for p in self.exclude_list):

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -214,9 +214,9 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:I:x:jpri:c:r:uC:nvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:tI:x:jpri:c:r:uC:nvqh', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
-            'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
+            'timestamp=', 'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
             'ionice=', 'config=', 'use-sudo', 'dry-run', 'removal-command=',
             'verbose', 'quiet', 'help',
         ])
@@ -233,6 +233,8 @@ def main():
                 rotation_scheme['monthly'] = coerce_retention_period(value)
             elif option in ('-y', '--yearly'):
                 rotation_scheme['yearly'] = coerce_retention_period(value)
+            elif option in ('-t', '--timestamp'):
+                kw['timestamp'].append(value)
             elif option in ('-I', '--include'):
                 kw['include_list'].append(value)
             elif option in ('-x', '--exclude'):

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -214,7 +214,7 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:tI:x:jpri:c:r:uC:nvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:t:I:x:jpri:c:r:uC:nvqh', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'timestamp=', 'include=', 'exclude=', 'parallel', 'prefer-recent', 'relaxed',
             'ionice=', 'config=', 'use-sudo', 'dry-run', 'removal-command=',


### PR DESCRIPTION

Many backup programs using timestamp formats which are not parseable from the default TIMESTAMP_PATTERN.

This change uses a timestamp property which by default is equal to TIMESTAMP but also can be specified either through rotate-backups.ini or as argument "-t" or "--timestamp="
