### PR TITLE
Add Dockerfile for rotate-backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.8-alpine as base
+FROM base as builder
+RUN mkdir /install
+COPY . /src
+RUN pip install --prefix=/install /src
+
+FROM base
+# Added system deps for runtime.
+RUN apk add less
+COPY --from=builder /install /usr/local
+COPY rotate_backups/ /app
+WORKDIR /app
+
+ENTRYPOINT ["rotate-backups"]
+CMD ["-h"]


### PR DESCRIPTION
Simple Docker build file to run this package.

Motivation is to run this as log rotator on my kubernetes cluster.
Image size is ~110MB
