### PR TITLE
File stat (e.g., `mtime`) timestamps

### DIFF
--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -604,7 +604,7 @@ class RotateBackups(PropertyManager):
         """Matcher to use to extract a timestamp from a file."""
         if not isinstance(matcher, Matcher):
             raise ValueError(f'{matcher} is not a Matcher')
-        set_property(self, '_matcher', matcher)
+        set_property(self, 'matcher', matcher)
 
     def rotate_concurrent(self, *locations, **kw):
         """

--- a/rotate_backups/__init__.py
+++ b/rotate_backups/__init__.py
@@ -228,6 +228,8 @@ def load_config_file(configuration_file=None, expand=True):
         # 'timestamp-pattern' configuration file option has a value set.
         if items.get('timestamp-pattern'):
             options['timestamp_pattern'] = items['timestamp-pattern']
+        if items.get('stat-timestamp'):
+            options['stat_timestamp'] = items['stat-timestamp']
         # Expand filename patterns?
         if expand and location.have_wildcards:
             logger.verbose("Expanding filename pattern %s on %s ..", location.directory, location.context)
@@ -404,9 +406,6 @@ class RotateBackups(PropertyManager):
         """
         options.update(rotation_scheme=rotation_scheme)
         super(RotateBackups, self).__init__(**options)
-        if self.stat_timestamp:
-            logger.info("Using file mtime to determine file date")
-            self.matcher = FilestatMatcher()
 
     @mutable_property
     def config_file(self):
@@ -550,6 +549,15 @@ class RotateBackups(PropertyManager):
     @mutable_property
     def stat_timestamp(self):
         """Whether to use the files' mtime instead of parsing their name."""
+        return isinstance(self.match, FilestatMatcher)
+
+    @stat_timestamp.setter
+    def stat_timestamp(self, value):
+        if value:
+            logger.info("Using file mtime to determine file date")
+            self.matcher = FilestatMatcher()
+        elif isinstance(self.match, FilestatMatcher):
+            del self.matcher
 
     @mutable_property
     def strict(self):

--- a/rotate_backups/cli.py
+++ b/rotate_backups/cli.py
@@ -168,6 +168,11 @@ Supported options:
     readable and/or writable for the current user (or the user logged in to a
     remote system over SSH).
 
+  -s, --stat-timestamp
+
+    Use mtime stat timestamps, instead of filenames, to determine the
+    date of each file.
+
   -S, --syslog=CHOICE
 
     Explicitly enable or disable system logging instead of letting the program
@@ -241,12 +246,12 @@ def main():
     selected_locations = []
     # Parse the command line arguments.
     try:
-        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:t:I:x:jpri:c:C:uS:fnvqh', [
+        options, arguments = getopt.getopt(sys.argv[1:], 'M:H:d:w:m:y:t:I:x:jpri:c:C:usS:fnvqh', [
             'minutely=', 'hourly=', 'daily=', 'weekly=', 'monthly=', 'yearly=',
             'timestamp-pattern=', 'include=', 'exclude=', 'parallel',
             'prefer-recent', 'relaxed', 'ionice=', 'config=',
-            'removal-command=', 'use-sudo', 'syslog=', 'force',
-            'dry-run', 'verbose', 'quiet', 'help',
+            'removal-command=', 'use-sudo', 'stat-timestamp', 'syslog=',
+            'force', 'dry-run', 'verbose', 'quiet', 'help',
         ])
         for option, value in options:
             if option in ('-M', '--minutely'):
@@ -284,6 +289,8 @@ def main():
                 kw['removal_command'] = removal_command
             elif option in ('-u', '--use-sudo'):
                 use_sudo = True
+            elif option in ('-s', '--stat-timestamp'):
+                kw['stat_timestamp'] = True
             elif option in ('-S', '--syslog'):
                 use_syslog = coerce_boolean(value)
             elif option in ('-f', '--force'):

--- a/rotate_backups/tests.py
+++ b/rotate_backups/tests.py
@@ -258,12 +258,12 @@ class RotateBackupsTestCase(TestCase):
             parser.set(subdir, 'monthly', '12')
             parser.set(subdir, 'yearly', 'always')
             parser.set(subdir, 'ionice', 'idle')
+            parser.set(subdir, 'stat-timestamp', 'yes')
             with open(config_file, 'w') as handle:
                 parser.write(handle)
             self.create_sample_backup_set(root)
             map = self.apply_mtime_and_rename(root, subdir)
-            run_cli(main, '--verbose', '--config=%s' % config_file,
-                    '--stat-timestamp')
+            run_cli(main, '--verbose', '--config=%s' % config_file)
             backups_that_were_preserved = set(os.listdir(subdir))
             assert backups_that_were_preserved == set([map[e]
                                                        for e in expected_to_be_preserved])


### PR DESCRIPTION
This introduces a modular way to extract dates from files. This is useful to use the `mtime` stat instead of parsing the filename, as mentioned in #19.

The modularity is added by adding a `Matcher` object, an implementation that use the `Filename`, and another that uses the `Stat` information